### PR TITLE
Disable main thread assert if main thread is unknown

### DIFF
--- a/utils-internal/src/androidMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
+++ b/utils-internal/src/androidMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
@@ -4,6 +4,16 @@ package com.arkivanov.mvikotlin.utils.internal
 
 import android.os.Looper
 
-internal actual val isMainThread: Boolean get() = Thread.currentThread().id == Looper.getMainLooper().thread.id
+internal actual fun getMainThreadId(): MainThreadId? =
+    try {
+        MainThreadId(Looper.getMainLooper().thread.id)
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
 
-internal actual val currentThreadDescription: String get() = Thread.currentThread().name
+internal actual fun isMainThread(mainThreadId: MainThreadId): Boolean = mainThreadId.id == Thread.currentThread().id
+
+internal actual fun getCurrentThreadDescription(): String = Thread.currentThread().toString()
+
+internal actual class MainThreadId(val id: Long)

--- a/utils-internal/src/commonMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
+++ b/utils-internal/src/commonMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
@@ -1,23 +1,55 @@
 package com.arkivanov.mvikotlin.utils.internal
 
 import com.badoo.reaktive.utils.atomic.AtomicBoolean
+import com.badoo.reaktive.utils.atomic.AtomicReference
+import com.badoo.reaktive.utils.atomic.getValue
+import com.badoo.reaktive.utils.atomic.setValue
 
-@Suppress("ObjectPropertyName")
-private val _isAssertOnMainThreadEnabled = AtomicBoolean(true)
-var isAssertOnMainThreadEnabled: Boolean
-    get() = _isAssertOnMainThreadEnabled.value
-    set(value) {
-        _isAssertOnMainThreadEnabled.value = value
-    }
+var isAssertOnMainThreadEnabled: Boolean by AtomicBoolean(true)
 
-internal expect val isMainThread: Boolean
-
-internal expect val currentThreadDescription: String
+private val mainThreadIdRef = AtomicReference<MainThreadIdHolder?>(null)
 
 fun assertOnMainThread() {
     if (isAssertOnMainThreadEnabled) {
-        require(isMainThread) {
-            "Not on Main thread, current thread is: $currentThreadDescription"
+        require(isMainThread()) {
+            "Not on Main thread, current thread is: ${getCurrentThreadDescription()}"
         }
     }
 }
+
+internal expect fun getMainThreadId(): MainThreadId?
+
+internal expect fun isMainThread(mainThreadId: MainThreadId): Boolean
+
+internal expect fun getCurrentThreadDescription(): String
+
+private fun isMainThread(): Boolean {
+    val mainThreadId =
+        mainThreadIdRef.initAndGet {
+            val id: MainThreadId? = getMainThreadId()
+            if (id == null) {
+                logE("Main thread id is undefined, main thread assert is disabled")
+            }
+            MainThreadIdHolder(id)
+        }
+
+    return mainThreadId.id?.let(::isMainThread) ?: true
+}
+
+private inline fun <T : Any> AtomicReference<T?>.initAndGet(init: () -> T): T {
+    while (true) {
+        var v: T? = value
+        if (v != null) {
+            return v
+        }
+
+        v = init()
+        if (compareAndSet(null, v)) {
+            return v
+        }
+    }
+}
+
+internal expect class MainThreadId
+
+private class MainThreadIdHolder(val id: MainThreadId?)

--- a/utils-internal/src/darwinCommonMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
+++ b/utils-internal/src/darwinCommonMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
@@ -2,6 +2,10 @@ package com.arkivanov.mvikotlin.utils.internal
 
 import platform.Foundation.NSThread
 
-internal actual val isMainThread: Boolean get() = NSThread.isMainThread()
+internal actual fun getMainThreadId(): MainThreadId? = MainThreadId()
 
-internal actual val currentThreadDescription: String get() = "Thread(name=${NSThread.currentThread().name()})"
+internal actual fun isMainThread(mainThreadId: MainThreadId): Boolean = NSThread.isMainThread()
+
+internal actual fun getCurrentThreadDescription(): String = "Thread(name=${NSThread.currentThread().name()})"
+
+internal actual class MainThreadId

--- a/utils-internal/src/jsMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
+++ b/utils-internal/src/jsMain/kotlin/com/arkivanov/mvikotlin/utils/internal/MainThreadAssert.kt
@@ -1,5 +1,9 @@
 package com.arkivanov.mvikotlin.utils.internal
 
-internal actual val isMainThread: Boolean = true
+internal actual fun getMainThreadId(): MainThreadId? = MainThreadId()
 
-internal actual val currentThreadDescription: String = "Main thread"
+internal actual fun isMainThread(mainThreadId: MainThreadId): Boolean = true
+
+internal actual fun getCurrentThreadDescription(): String = "Main thread"
+
+internal actual class MainThreadId


### PR DESCRIPTION
This can be useful in tests, so there is no need to disable Main thread asserts